### PR TITLE
docs: developer setup guide and env example

### DIFF
--- a/deploy/compose/.env.ce.example
+++ b/deploy/compose/.env.ce.example
@@ -1,0 +1,19 @@
+# Phase 0 CE Compose env (local-only). Copy to .env.ce and edit as needed.
+# Do not commit deploy/compose/.env.ce
+
+# Core ports
+KEYCLOAK_PORT=8080
+VAULT_PORT=8200
+POSTGRES_PORT=5432
+OLLAMA_PORT=11434
+
+# Optional S3-compatible storage (OFF by default)
+S3_PROVIDER=off # off|seaweedfs|minio|garage
+SEAWEED_S3_PORT=8333
+SEAWEED_MASTER_PORT=9333
+SEAWEED_FILER_PORT=8081
+MINIO_API_PORT=9000
+MINIO_CONSOLE_PORT=9001
+
+# Feature toggles
+ALLOW_DISABLE_OLLAMA=true

--- a/docs/guides/dev-setup.md
+++ b/docs/guides/dev-setup.md
@@ -1,22 +1,45 @@
 # Developer Setup (Phase 0)
 
-Prerequisites
-- Docker (Engine or Desktop)
-- Bash, curl, ss, awk
-- Optional: Node.js (for Spectral OpenAPI lint)
+This guide covers Linux/macOS prerequisites, repo overview, default ports, override mechanism, and Phase 0 smoke steps.
 
-Steps
-1) Port preflight
-   - `make preflight` (or `scripts/dev/preflight_ports.sh`)
-2) Configure env overrides (optional)
-   - Create a local `deploy/compose/.env.ce` and adjust ports (see docs/guides/ports.md)
-3) Compose (Phase 1 will include ce.dev.yml)
-   - For now, we focus on scaffolding and docs; compose file lands in Phase 1.
-4) Guard model (when using Ollama)
-   - See docs/guides/guard-model-selection.md for defaults and alternatives.
-5) OpenAPI lint (optional in Phase 0)
-   - `make lint-openapi` (warn-only)
+## Prerequisites
+- Docker (CPU-only; no GPU required)
+- Git (SSH recommended)
+- Optional: Spectral (`npm i -g @stoplight/spectral-cli`) for OpenAPI lint (warn-only)
 
-Notes
-- Models are not bundled; you will be prompted to pull with consent when needed.
-- Object storage is optional and OFF by default; see docs/guides/object-storage.md.
+## OS Support
+- Linux and macOS are supported for Phase 0 scaffolding.
+
+## Repository Layout (high level)
+- services/ (reserved for future runtime services)
+- deploy/compose/ (docker compose files, env examples)
+- docs/ (architecture, ADRs, guides, api, security)
+- config/ (templates and configurations)
+- db/ (migrations and notes)
+- scripts/ (dev helpers)
+
+## Default Ports and Overrides
+See [Ports Registry](./ports.md) for the authoritative list and strategy.
+Defaults (Phase 0): Keycloak 8080, Vault 8200, Postgres 5432, Ollama 11434,
+SeaweedFS 8333/9333/8081, MinIO 9000/9001.
+
+Override via `deploy/compose/.env.ce` (local-only, not committed).
+
+## Local env file
+1. Copy: `cp deploy/compose/.env.ce.example deploy/compose/.env.ce`
+2. Edit values as needed.
+
+## Smoke checks (Phase 0)
+- Read [docs/tests/smoke-phase0.md] for commands to validate:
+  - Preflight ports
+  - Compose bring-up (infra only) and health verification
+  - OpenAPI lint (warn-only)
+  - Presence of schemas and migrations
+
+## Known Issues / Troubleshooting
+- If ports are occupied, adjust in `.env.ce` and retry
+- If `gh` CLI is missing, use Git web UI to open PRs
+- S3-compatible object storage is OFF by default per ADR-0014; enabling is optional and documented.
+
+## Secrets and Keys (dev only)
+See [docs/security/secrets-bootstrap.md] for Vault dev mode notes and key handling. Do not commit secrets.


### PR DESCRIPTION
Developer setup guide for Linux/macOS with port overrides and smoke steps. Adds .env.ce.example.

Changes:
- Add/refresh docs/guides/dev-setup.md
- Add deploy/compose/.env.ce.example with defaults and comments

Refs: docs/guides/ports.md, docs/tests/smoke-phase0.md
