### PR TITLE
docs: add VERSION_PINS and ports registry

### DIFF
--- a/VERSION_PINS.md
+++ b/VERSION_PINS.md
@@ -1,19 +1,15 @@
-# Version Pins (Phase 0)
+# VERSION_PINS (Phase 0)
 
-Pin external service versions to reduce drift. Update deliberately via PR.
+Pin all images explicitly (no :latest). Tags may evolve later; update via PR.
 
-- Keycloak: 26.0.0 (example; adjust if needed)
-- Vault OSS: 1.17.6 (example)
-- Postgres: 16.4
-- Ollama: 0.3.x (>= 0.3.0)
-- MinIO (opt-in): RELEASE.2025-01-25T00-00-00Z (AGPLv3) — optional
-- Garage (opt-in): latest stable (AGPLv3) — documented alternative only
-- SeaweedFS (opt-in default for ALv2 option): 3.68 (Apache-2.0)
+- Keycloak: quay.io/keycloak/keycloak:24.0.4
+- Vault: hashicorp/vault:1.17.6
+- Postgres: postgres:16.4-alpine
+- Ollama: ollama/ollama:0.3.14
+- SeaweedFS: chrislusf/seaweedfs:3.68
+- MinIO: minio/minio:RELEASE.2024-09-22T00-00-00Z
+- Garage (optional): dxflrs/garage:0.9.3
 
-Guard models (documented; not bundled):
-- Default: llama3.2:1b (instruct), quant Q4_K_M suggested
-- Quality mode: llama3.2:3b (instruct), quant Q4_K_M/Q5_K_M
-- Fallback tiny: tinyllama:1.1b
-- Optional: phi3:3.8b; qwen2.5:~1.5b instruct
-
-Note: Model weights are not distributed with this repo. First-run pulls are user-approved and logged.
+Notes:
+- Guard model tags: document selections in docs/guides/guard-model-selection.md; do not bundle weights in repo.
+- HTTP-only posture and metadata-only storage per ADR-0010/0012.

--- a/docs/guides/ports.md
+++ b/docs/guides/ports.md
@@ -1,17 +1,15 @@
-# Ports (Defaults and Overrides)
+# Ports Registry (Phase 0)
 
-Standardize defaults for a predictable developer experience. Override via environment.
-
-Defaults (override via a local `.env.ce` you create under `deploy/compose/` — not tracked by repo):
+Default ports:
 - Keycloak: 8080
 - Vault: 8200
 - Postgres: 5432
 - Ollama: 11434
-- MinIO (opt-in): 9000 (S3), 9001 (console)
-- SeaweedFS (opt-in): 8333 (S3), 9333 (master UI), 8081 (Filer API)
+- SeaweedFS: 8333 (S3), 9333 (master), 8081 (filer)
+- MinIO: 9000 (API), 9001 (Console)
 
-Preflight check
-- Use `scripts/dev/preflight_ports.sh` to detect conflicts and suggest alternatives before `docker compose up`.
+Override strategy:
+- Use `deploy/compose/.env.ce` to set environment variables consumed by compose files.
+- Example: set `KEYCLOAK_PORT=8088` to change Keycloak’s host port.
 
-Overrides
-- Create a local `deploy/compose/.env.ce` (ignored by repo policy) and adjust ports, e.g.: `KEYCLOAK_PORT=18080`.
+See also: `deploy/compose/.env.ce.example` and docs/guides/dev-setup.md.


### PR DESCRIPTION
Establishes explicit version pins (no :latest) and documents default ports/override strategy.

Changes:
- Update VERSION_PINS.md with pinned tags
- Update docs/guides/ports.md with defaults and env override approach
- Cross-link from dev-setup.md
