### PR TITLE
build: add CE compose baseline and healthchecks

### DIFF
--- a/deploy/compose/ce.dev.yml
+++ b/deploy/compose/ce.dev.yml
@@ -1,0 +1,95 @@
+services:
+  postgres:
+    image: postgres:16.4-alpine
+    container_name: ce_postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0.4
+    container_name: ce_keycloak
+    command: ["start-dev", "--http-port=8080"]
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+  vault:
+    image: hashicorp/vault:1.17.6
+    container_name: ce_vault
+    cap_add: ["IPC_LOCK"]
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: root
+      VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+    ports:
+      - "8200:8200"
+    command: vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8200/v1/sys/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+  ollama:
+    image: ollama/ollama:0.3.14
+    container_name: ce_ollama
+    environment:
+      - OLLAMA_HOST=0.0.0.0
+    ports:
+      - "11434:11434"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:11434/api/tags || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+    deploy:
+      replicas: 1
+    profiles: ["ollama"]
+
+  # S3-compatible storage (OFF by default). Enable via S3_PROVIDER env or compose profiles as needed.
+  seaweedfs:
+    image: chrislusf/seaweedfs:3.68
+    container_name: ce_seaweed
+    command: ["server", "-s3", "-s3.port=8333", "-master.port=9333", "-filer.port=8081"]
+    ports:
+      - "8333:8333"
+      - "9333:9333"
+      - "8081:8081"
+    profiles: ["s3-seaweedfs"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9333/cluster/status || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+
+  minio:
+    image: minio/minio:RELEASE.2024-09-22T00-00-00Z
+    container_name: ce_minio
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    profiles: ["s3-minio"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/minio/health/ready || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+
+# Note: Use  to enable optional services.

--- a/deploy/compose/healthchecks/keycloak.sh
+++ b/deploy/compose/healthchecks/keycloak.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+curl -fsS http://localhost:${KEYCLOAK_PORT:-8080} > /dev/null

--- a/deploy/compose/healthchecks/minio.sh
+++ b/deploy/compose/healthchecks/minio.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+curl -fsS http://localhost:${MINIO_API_PORT:-9000}/minio/health/ready > /dev/null

--- a/deploy/compose/healthchecks/ollama.sh
+++ b/deploy/compose/healthchecks/ollama.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+curl -fsS http://localhost:${OLLAMA_PORT:-11434}/api/tags > /dev/null

--- a/deploy/compose/healthchecks/postgres.sh
+++ b/deploy/compose/healthchecks/postgres.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PGPORT=${POSTGRES_PORT:-5432}
+pg_isready -h 127.0.0.1 -p "$PGPORT" -U postgres

--- a/deploy/compose/healthchecks/vault.sh
+++ b/deploy/compose/healthchecks/vault.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+curl -fsS http://localhost:${VAULT_PORT:-8200}/v1/sys/health > /dev/null

--- a/docs/guides/compose-ce.md
+++ b/docs/guides/compose-ce.md
@@ -1,27 +1,17 @@
 # CE Compose (Phase 0)
 
-Decision highlights
-- Object storage is opt-in. Default profile runs without S3.
-- Provide multiple S3 options via profiles/env (SeaweedFS default ALv2 option; MinIO/Garage alternatives; Ozone for scale later).
-- Standard ports with .env overrides (see docs/guides/ports.md). Run preflight checks before `up`.
+Steps:
+1. Copy env: `cp deploy/compose/.env.ce.example deploy/compose/.env.ce` and adjust ports.
+2. Bring up infra only:
+   - Basic: `docker compose -f deploy/compose/ce.dev.yml up -d`
+   - Enable Ollama: `docker compose -f deploy/compose/ce.dev.yml --profile ollama up -d`
+   - Enable SeaweedFS: `docker compose -f deploy/compose/ce.dev.yml --profile s3-seaweedfs up -d`
+   - Enable MinIO: `docker compose -f deploy/compose/ce.dev.yml --profile s3-minio up -d`
+3. Verify health:
+   - `deploy/compose/healthchecks/keycloak.sh`
+   - `deploy/compose/healthchecks/vault.sh`
+   - `deploy/compose/healthchecks/postgres.sh`
+   - `deploy/compose/healthchecks/ollama.sh` (if profile enabled)
+   - `deploy/compose/healthchecks/minio.sh` (if profile enabled)
 
-What this profile includes now (in Phase 0)
-- Keycloak (OIDC): ${KEYCLOAK_PORT:-8080}
-- Vault OSS (dev): ${VAULT_PORT:-8200}
-- Postgres: ${POSTGRES_PORT:-5432}
-- Ollama (local models): ${OLLAMA_PORT:-11434}
-- Object storage: disabled by default; see below
-
-Profiles (to be added in Phase 1)
-- seaweedfs: enables SeaweedFS S3 gateway
-- minio: enables MinIO
-- garage: enables Garage
-
-Preflight
-- Run `scripts/dev/preflight_ports.sh` to detect port conflicts.
-
-Model provisioning
-- Models are not bundled. On first use, `ollama pull <model>` with explicit consent. See docs/guides/guard-model-selection.md.
-
-License & notices
-- See docs/THIRD_PARTY.md for license and links of optional services.
+S3 is OFF by default. See ADR-0014 for policy details.


### PR DESCRIPTION
Infra-only CE compose baseline with healthchecks and optional profiles (ollama, s3-seaweedfs, s3-minio). S3 off by default.

Changes:
- Add deploy/compose/ce.dev.yml
- Add healthcheck scripts under deploy/compose/healthchecks/
- Update docs/guides/compose-ce.md with usage and health verification

Ports driven by deploy/compose/.env.ce. See docs/guides/dev-setup.md.
