### PR TITLE
docs: add audit event and profile bundle schema stubs

### DIFF
--- a/config/profiles/sample/marketing.yaml.sig
+++ b/config/profiles/sample/marketing.yaml.sig
@@ -1,0 +1,1 @@
+# TODO: sample signed profile for marketing (placeholder only)

--- a/docs/audit/audit-event.schema.json
+++ b/docs/audit/audit-event.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/audit-event.schema.json",
+  "title": "AuditEvent",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "ts": { "type": "string", "format": "date-time" },
+    "tenantId": { "type": "string" },
+    "actor": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "type": "string" },
+        "role": { "type": "string" }
+      },
+      "required": ["id", "type"]
+    },
+    "action": { "type": "string" },
+    "target": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "type": "string" }
+      },
+      "required": ["id", "type"]
+    },
+    "result": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string" },
+        "reason": { "type": "string" }
+      },
+      "required": ["status"]
+    },
+    "redactions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ruleId": { "type": "string" },
+          "field": { "type": "string" },
+          "hash": { "type": "string" }
+        },
+        "required": ["ruleId", "field", "hash"]
+      }
+    },
+    "cost": {
+      "type": "object",
+      "properties": {
+        "inputTokens": { "type": "integer", "minimum": 0 },
+        "outputTokens": { "type": "integer", "minimum": 0 },
+        "currency": { "type": "string", "default": "USD" }
+      }
+    },
+    "traceId": { "type": "string" },
+    "hashPrev": { "type": "string" },
+    "tenant": { "type": "string" }
+  },
+  "required": ["id", "ts", "tenantId", "actor", "action", "target", "result"]
+}

--- a/docs/policy/profile-bundle.schema.yaml
+++ b/docs/policy/profile-bundle.schema.yaml
@@ -1,0 +1,37 @@
+# Profile Bundle Schema (Phase 0 stub)
+# Captures metadata for signed bundles; content constraints refined later.
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://example.org/schemas/profile-bundle.schema.yaml
+
+title: ProfileBundle
+type: object
+properties:
+  id: { type: string }
+  version: { type: string }
+  createdAt: { type: string, format: date-time }
+  expiresAt: { type: string, format: date-time }
+  roles:
+    type: array
+    items: { type: object }
+  policies:
+    type: array
+    items: { type: object }
+  signatures:
+    type: array
+    items:
+      type: object
+      properties:
+        alg: { type: string, enum: [Ed25519] }
+        signature: { type: string }
+        keyId: { type: string }
+      required: [alg, signature, keyId]
+  publicKeys:
+    type: array
+    items:
+      type: object
+      properties:
+        keyId: { type: string }
+        alg: { type: string, enum: [Ed25519] }
+        publicKey: { type: string }
+      required: [keyId, alg, publicKey]
+required: [id, version, roles, policies, signatures, publicKeys, createdAt]


### PR DESCRIPTION
Adds stubs for AuditEvent and Profile Bundle schemas, referenced by API docs.

Changes:
- Add docs/audit/audit-event.schema.json
- Add docs/policy/profile-bundle.schema.yaml
- Add config/profiles/sample/marketing.yaml.sig placeholder
