### PR TITLE
docs(components): add components index and Phase Alignment sections with cross-links

### DIFF
--- a/Technical Project Plan/components/README.md
+++ b/Technical Project Plan/components/README.md
@@ -1,0 +1,20 @@
+# Components — Index and Phase Alignment
+
+This directory contains component-level plans. Each component README includes a Phase Alignment section mapping:
+- Phase 0 (completed): links to concrete artifacts delivered.
+- Phase 1 (planned): scope for this phase with cross-links to execution plan.
+- Later Phases: deferred work.
+
+Global references:
+- Phase 0 Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+- Phase 1 Execution Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+- OpenAPI stub: ../../docs/api/controller/openapi.yaml
+- AuditEvent schema: ../../docs/audit/audit-event.schema.json
+- Profile bundle schema: ../../docs/policy/profile-bundle.schema.yaml
+- Compose baseline: ../../deploy/compose/ce.dev.yml
+- DB migrations (metadata-only): ../../db/migrations/metadata-only/0001_init.sql
+- Dev setup: ../../docs/guides/dev-setup.md
+- Compose guide: ../../docs/guides/compose-ce.md
+- Secrets bootstrap: ../../docs/security/secrets-bootstrap.md
+- Keycloak dev: ../../docs/guides/keycloak-dev.md
+- Version pins: ../../VERSION_PINS.md

--- a/Technical Project Plan/components/agent-mesh-mcp/README.md
+++ b/Technical Project Plan/components/agent-mesh-mcp/README.md
@@ -6,3 +6,14 @@ Overview: Standard MCP extension offering cross-agent verbs: send_task, request_
 - Task delivery success ≥ 99%
 - Median call latency ≤ 300ms intra-VPC
 - Policy violation rate < 1% (caught)
+
+## Phase Alignment
+
+- Phase 0 (completed)
+  - Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+  - ADR-0007: ../../docs/adr/0007-agent-mesh-mcp.md
+- Phase 1 (planned)
+  - Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+  - No runtime changes; planning docs only
+- Later phases
+  - Refer to master plan: ../master-technical-project-plan.md

--- a/Technical Project Plan/components/audit-observability/README.md
+++ b/Technical Project Plan/components/audit-observability/README.md
@@ -6,3 +6,14 @@ Overview: OTLP traces, structured logs, audit event ingest and export (ndjson). 
 - 100% audit events redacted as needed
 - Export job completion < 2m for 100k events
 - Trace sampling 5–10% with minimal overhead
+
+## Phase Alignment
+
+- Phase 0 (completed)
+  - Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+  - AuditEvent schema: ../../docs/audit/audit-event.schema.json\n- Compose baseline and health scripts: ../../deploy/compose/healthchecks/
+- Phase 1 (planned)
+  - Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+  - Observability doc with logging fields (traceId, actor, redactions)\n- Ensure no PII logs
+- Later phases
+  - Refer to master plan: ../master-technical-project-plan.md

--- a/Technical Project Plan/components/controller-api/README.md
+++ b/Technical Project Plan/components/controller-api/README.md
@@ -6,3 +6,14 @@ Overview: Minimal HTTP controller that routes tasks, handles approvals, session 
 - 99.5% availability
 - p95 route latency ≤ 200ms (excluding agent processing)
 - OpenAPI client codegen successful in CI
+
+## Phase Alignment
+
+- Phase 0 (completed)
+  - Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+  - OpenAPI stub: ../../docs/api/controller/openapi.yaml\n- Schemas: ../../docs/api/schemas/README.md\n- AuditEvent schema: ../../docs/audit/audit-event.schema.json
+- Phase 1 (planned)
+  - Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+  - Minimal controller runtime (status, audit ingest stubs)\n- Spectral lint + linkcheck in CI\n- Compose integration and healthcheck
+- Later phases
+  - Refer to master plan: ../master-technical-project-plan.md

--- a/Technical Project Plan/components/directory-policy/README.md
+++ b/Technical Project Plan/components/directory-policy/README.md
@@ -6,3 +6,14 @@ Overview: Role profiles, org graph, signed profile bundles, policy evaluation (R
 - Policy decision latency p95 ≤ 50ms
 - Signed bundle integrity: 100% verification
 - Profile rollout time ≤ 5m
+
+## Phase Alignment
+
+- Phase 0 (completed)
+  - Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+  - Profile bundle schema: ../../docs/policy/profile-bundle.schema.yaml\n- ADR-0011: ../../docs/adr/0011-directory-policy-profile-bundles.md
+- Phase 1 (planned)
+  - Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+  - Documentation and schema references; enforcement deferred
+- Later phases
+  - Refer to master plan: ../master-technical-project-plan.md

--- a/Technical Project Plan/components/identity-auth-gateway/README.md
+++ b/Technical Project Plan/components/identity-auth-gateway/README.md
@@ -7,3 +7,14 @@ Overview: Front door for OIDC SSO and JWT issuance; bridges to goosed (X-Secret-
 - Token TTL ≤ 30m, rotation within 5m grace
 - Median login time ≤ 3s
 - Authn errors < 0.5%
+
+## Phase Alignment
+
+- Phase 0 (completed)
+  - Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+  - Keycloak dev notes: ../../docs/guides/keycloak-dev.md\n- Secrets bootstrap: ../../docs/security/secrets-bootstrap.md
+- Phase 1 (planned)
+  - Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+  - Dev-only seeding docs/scripts; runtime gateway deferred
+- Later phases
+  - Refer to master plan: ../master-technical-project-plan.md

--- a/Technical Project Plan/components/model-orchestration/README.md
+++ b/Technical Project Plan/components/model-orchestration/README.md
@@ -6,3 +6,14 @@ Overview: Lead/worker provider routing with guard-first; cost-aware downshift; p
 - Downshift rate for summaries ≥ 50%
 - Cost variance within budget ±10%
 - p95 plan+execute within targets
+
+## Phase Alignment
+
+- Phase 0 (completed)
+  - Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+  - Guard model selection doc: ../../docs/guides/guard-model-selection.md\n- ADR-0015: ../../docs/adr/0015-guard-model-policy-and-selection.md
+- Phase 1 (planned)
+  - Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+  - No runtime changes; planning docs only
+- Later phases
+  - Refer to master plan: ../master-technical-project-plan.md

--- a/Technical Project Plan/components/packaging-deployment/README.md
+++ b/Technical Project Plan/components/packaging-deployment/README.md
@@ -6,3 +6,14 @@ Overview: Desktop agents + services (controller, directory-policy, audit) with C
 - Quickstart time ≤ 30 minutes
 - Demo script runs end-to-end first time
 - CI build success ≥ 95%
+
+## Phase Alignment
+
+- Phase 0 (completed)
+  - Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+  - Compose baseline: ../../deploy/compose/ce.dev.yml\n- Health scripts: ../../deploy/compose/healthchecks/
+- Phase 1 (planned)
+  - Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+  - CI workflow: linkcheck, spectral, compose health
+- Later phases
+  - Refer to master plan: ../master-technical-project-plan.md

--- a/Technical Project Plan/components/privacy-guard/README.md
+++ b/Technical Project Plan/components/privacy-guard/README.md
@@ -6,3 +6,14 @@ Overview: Local pre/post masking and deterministic pseudonymization; supports de
 - Overhead ≤ 500ms P50
 - False negative rate for key PII classes ≤ 3% in test set
 - Zero raw PII in audit logs
+
+## Phase Alignment
+
+- Phase 0 (completed)
+  - Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+  - ADR-0002: ../../docs/adr/0002-privacy-guard-placement.md\n- AuditEvent schema (redactions metadata): ../../docs/audit/audit-event.schema.json
+- Phase 1 (planned)
+  - Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+  - Document redaction metadata expectations; runtime enforcement deferred
+- Later phases
+  - Refer to master plan: ../master-technical-project-plan.md

--- a/Technical Project Plan/components/security-secrets/README.md
+++ b/Technical Project Plan/components/security-secrets/README.md
@@ -6,3 +6,14 @@ Overview: Vault + KMS (CE: Vault OSS, file KMS for dev). Manages signing keys, p
 - Key rotation executed on schedule
 - Zero secrets in git
 - Access policy violations = 0
+
+## Phase Alignment
+
+- Phase 0 (completed)
+  - Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+  - Secrets bootstrap: ../../docs/security/secrets-bootstrap.md\n- Keycloak dev guide: ../../docs/guides/keycloak-dev.md
+- Phase 1 (planned)
+  - Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+  - Vault dev bootstrap script; Keycloak seeding script (idempotent)
+- Later phases
+  - Refer to master plan: ../master-technical-project-plan.md

--- a/Technical Project Plan/components/storage-metadata/README.md
+++ b/Technical Project Plan/components/storage-metadata/README.md
@@ -6,3 +6,14 @@ Overview: Postgres metadata for tasks/sessions/approvals/audit index. Object sto
 - DB p95 query ≤ 50ms for primary indexes
 - Retention jobs complete daily
 - Zero raw content persisted server-side
+
+## Phase Alignment
+
+- Phase 0 (completed)
+  - Summary: ../PM Phases/Phase-0/Phase-0-Summary.md
+  - Metadata-only migrations: ../../db/migrations/metadata-only/0001_init.sql\n- DB README: ../../db/README.md
+- Phase 1 (planned)
+  - Plan: ../PM Phases/Phase-1/Phase-1-Execution-Plan.md
+  - Indexes/FKs where low-risk; migration runner docs
+- Later phases
+  - Refer to master plan: ../master-technical-project-plan.md


### PR DESCRIPTION
Adds components/README.md as an index and appends a standardized "Phase Alignment" section to each component README linking Phase 0 artifacts and Phase 1 plan. Cross-links to OpenAPI, schemas, compose, migrations, dev-setup, and ADRs.

This is docs-only; no moves/renames. Linkcheck should pass under Phase 1 CI.