### PR TITLE
docs: Ollama port conflict notes + ADR-0017 (Rust controller) + Phase 1 optional cleanup workstream

### DIFF
--- a/Technical Project Plan/PM Phases/Phase-1/Phase-1-Agent-Prompts.md
+++ b/Technical Project Plan/PM Phases/Phase-1/Phase-1-Agent-Prompts.md
@@ -222,3 +222,19 @@ Acceptance:
 ## Copy/paste usage
 - Copy this entire document as the Phase 1 “Master Orchestrator Prompt” when running an orchestrated build for Phase 1.
 - Follow the sequence A→F, pausing for inputs per the Pause/Resume protocol. Use the provided branch names and commit messages.
+
+
+### Prompt G — Repository-wide documentation/file audit and cleanup (optional)
+Objective:
+- Review all documentation and files in the repo, identify inconsistencies, dead links, and organizational issues.
+- Changes are approval-gated; ask before moving/renaming files.
+
+Tasks:
+1) Run linkcheck/ref audit across repo; produce a report (docs/tests/repo-audit-phase1.md).
+2) Propose minimal changes (rename/moves) in a PR and pause for approval.
+3) Upon approval, apply changes and re-run audit.
+
+Acceptance:
+- Report delivered; if approved changes applied, linkcheck passes.
+
+Note: This workstream is optional and requires explicit approval before any moves.

--- a/Technical Project Plan/PM Phases/Phase-1/Phase-1-Execution-Plan.md
+++ b/Technical Project Plan/PM Phases/Phase-1/Phase-1-Execution-Plan.md
@@ -35,6 +35,7 @@ Owner: Phase 1 Orchestrator
 - VERSION_PINS.md for images
 
 ## Workstreams and Tasks
+- Optional: G — Repo-wide documentation/file audit & cleanup (approval-gated)
 - A: Planning + CI foundation
   - A1: Author Phase-1 docs (Execution Plan, Checklist, Assumptions)
   - A2: CI skeleton (linkcheck, spectral, compose health)

--- a/Technical Project Plan/components/controller-api/README.md
+++ b/Technical Project Plan/components/controller-api/README.md
@@ -17,3 +17,4 @@ Overview: Minimal HTTP controller that routes tasks, handles approvals, session 
   - Minimal controller runtime (status, audit ingest stubs)\n- Spectral lint + linkcheck in CI\n- Compose integration and healthcheck
 - Later phases
   - Refer to master plan: ../master-technical-project-plan.md
+\n- ADR-0017: ../../docs/adr/0017-controller-language-and-runtime-choice.md

--- a/docs/adr/0017-controller-language-and-runtime-choice.md
+++ b/docs/adr/0017-controller-language-and-runtime-choice.md
@@ -1,0 +1,29 @@
+# 0017 — Controller Language and Runtime Choice (Rust)
+
+Status: Accepted
+Date: 2025-10-31
+
+## Context
+Phase 1 requires a minimal Controller runtime aligned with the OpenAPI stub (HTTP-only, metadata-only). We must choose a language/runtime that supports security, performance, and long-term maintainability, and aligns with Goose ecosystem practices.
+
+## Decision
+Use Rust for the Controller runtime baseline in Phase 1.
+
+## Rationale
+- Security/Robustness: Strong typing and memory safety reduce classes of runtime errors.
+- Performance/Footprint: Predictable latency and small static binaries simplify CE deployments.
+- Ecosystem: axum/actix-web, serde, tracing, OpenTelemetry crates, sqlx for metadata when needed.
+- Alignment: Goose upstream is Rust-heavy; improves reuse and contributor familiarity.
+
+## Consequences
+- Slightly higher initial ramp vs Node/Python; mitigated with templates and docs.
+- CI builds may be longer; mitigated with caching.
+- Container images can be minimal (alpine/distroless) with a static binary.
+
+## Alternatives Considered
+- Node (TypeScript): Faster iteration, broader familiarity; higher runtime footprint and supply-chain diligence.
+- Python (FastAPI): Rapid prototyping; lower throughput and deployment considerations.
+
+## References
+- docs/api/controller/openapi.yaml
+- Technical Project Plan/PM Phases/Phase-1/Phase-1-Execution-Plan.md

--- a/docs/guides/compose-ce.md
+++ b/docs/guides/compose-ce.md
@@ -15,3 +15,9 @@ Steps:
    - `deploy/compose/healthchecks/minio.sh` (if profile enabled)
 
 S3 is OFF by default. See ADR-0014 for policy details.
+
+## Port conflicts (Ollama)
+
+- Ollama defaults to host port 11434. If you already run a host Ollama (e.g., Goose Desktop), do not enable the compose `ollama` profile at the same time.
+- Alternatively, override OLLAMA_PORT in deploy/compose/.env.ce and re-run compose.
+- See also: docs/guides/dev-setup.md (Known Issues) and docs/guides/ports.md.

--- a/docs/guides/dev-setup.md
+++ b/docs/guides/dev-setup.md
@@ -47,6 +47,7 @@ Override via `deploy/compose/.env.ce` (local-only, not committed).
 - If ports are occupied, adjust in `.env.ce` and retry
 - If `gh` CLI is missing, use Git web UI to open PRs
 - S3-compatible object storage is OFF by default per ADR-0014; enabling is optional and documented.
+- Ollama port conflict: if Goose Desktop or a host Ollama is running on 11434, do not enable the compose `ollama` profile, or override OLLAMA_PORT in deploy/compose/.env.ce.
 
 ## Secrets and Keys (dev only)
 See [docs/security/secrets-bootstrap.md] for Vault dev mode notes and key handling. Do not commit secrets.

--- a/docs/guides/ports.md
+++ b/docs/guides/ports.md
@@ -13,3 +13,6 @@ Override strategy:
 - Example: set `KEYCLOAK_PORT=8088` to change Keycloak’s host port.
 
 See also: `deploy/compose/.env.ce.example` and docs/guides/dev-setup.md.
+
+## Notes
+- 11434 is the common host port for Ollama. If a host Ollama is running, the compose `ollama` profile will conflict unless you override OLLAMA_PORT or disable the profile.


### PR DESCRIPTION
Adds:
- Ollama port conflict notes to compose-ce.md, dev-setup.md (Known Issues), and ports.md; advises overriding OLLAMA_PORT or disabling ollama profile.
- ADR-0017: Controller language/runtime choice (Rust) — Accepted.
- Phase 1 prompt/plan: Optional Workstream G for repo-wide doc/file audit & cleanup (approval-gated).
- controller-api component README: link to ADR-0017.

Docs-only change; improves future references and Phase 1 guidance.