### PR TITLE
docs(phase1): lock Rust + 8088 decisions in Phase-1 prompt and plan

### DIFF
--- a/Technical Project Plan/PM Phases/Phase-1/Phase-1-Agent-Prompts.md
+++ b/Technical Project Plan/PM Phases/Phase-1/Phase-1-Agent-Prompts.md
@@ -2,6 +2,12 @@
 
 ## Master Orchestrator Prompt — Phase 1
 
+## Decisions
+
+- Controller language: Rust (see ADR-0017 — docs/adr/0017-controller-language-and-runtime-choice.md)
+- Controller port: 8088 (override via deploy/compose/.env.ce as CONTROLLER_PORT)
+
+
 Role: Phase 1 Orchestrator for goose-org-twin
 
 You are an engineering orchestrator responsible for executing Phase 1 of the Technical Project Plan. Implement initial runtime scaffolding, CI, minimal service endpoints consistent with ADRs and the OpenAPI stub, developer seeding scripts, and acceptance tests. Maintain HTTP-only posture and metadata-only server model. Be pause/resume capable and persist state.
@@ -35,7 +41,7 @@ State persistence (mandatory):
       "github_remote": "git@github.com:ORG/repo.git",
       "git_user_name": "",
       "git_user_email": "",
-      "runtime_lang": "rust|node|python",
+      "runtime_lang": "rust",
       "db_url": "postgres://... (dev-only)",
       "ports": {"controller":8088, "keycloak":8080, "vault":8200, "postgres":5432, "ollama":11434},
       "s3_provider": "off|seaweedfs|minio|garage",
@@ -79,7 +85,7 @@ Before starting Workstream A, collect/confirm user inputs (store in state):
 - OS: linux or macos; Docker available: yes/no
 - Git identity (name/email); Git remote (SSH)
 - Default branch name (default: main)
-- Runtime language for controller: rust|node|python (default rust)
+- Runtime language is fixed: rust (see ADR-0017).
 - Controller port (default 8088), DB URL (from compose Postgres)
 - S3 provider: off (default) | seaweedfs | minio | garage
 - Allow disabling Ollama service via env var: true/false (default true)

--- a/Technical Project Plan/PM Phases/Phase-1/Phase-1-Execution-Plan.md
+++ b/Technical Project Plan/PM Phases/Phase-1/Phase-1-Execution-Plan.md
@@ -31,6 +31,7 @@ Owner: Phase 1 Orchestrator
 - docs/tests/smoke-phase1.md; CHANGELOG updated
 
 ## Dependencies
+- ADR-0017 (Rust controller language): ../PM Phases/Phase-1/../../docs/adr/0017-controller-language-and-runtime-choice.md
 - Phase 0 artifacts (compose infra, schemas, OpenAPI stub)
 - VERSION_PINS.md for images
 


### PR DESCRIPTION
Pins Phase 1 decisions in orchestrator docs:
- Phase-1-Agent-Prompts.md: Adds Decisions section (Rust controller per ADR-0017; controller port 8088), fixes user_inputs to runtime_lang=rust, and removes language question from pre-start.
- Phase-1-Execution-Plan.md: Adds ADR-0017 link in Dependencies.

This ensures Phase 1 sessions won’t re-ask for language and default to 8088 unless overridden in .env.ce.